### PR TITLE
#9 feat: adicionar listagem de tópicos com template dinamico

### DIFF
--- a/learning_logs/templates/learning_logs/topics.html
+++ b/learning_logs/templates/learning_logs/topics.html
@@ -1,0 +1,13 @@
+{% extends "learning_logs/base.html" %}
+
+{% block content %} 
+
+    <ul>
+        {% for topic in topics%}
+            <li> {{ topic }} </li>
+        {% empty %}
+            <li>Nenhum tópico foi adicionado ainda.</li>
+        {% endfor %}
+    </ul>
+
+{% endblock content %}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('topics', views.topics, name='topics'),
 ]

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -1,5 +1,12 @@
 from django.shortcuts import render
+from .models import Topic
 
 def index(request):
     """Pagina principal do Learning_Log"""
     return render(request, 'learning_logs/index.html')
+
+def topics(request):
+    """Mostra todos os assuntos"""
+    topics = Topic.objects.order_by('date_added')
+    context = {'topics': topics}
+    return render(request, 'learning_logs/topics.html', context)


### PR DESCRIPTION
- Criada a view `topics()` em `views.py` que consulta e ordena os tópicos por `date_added`
- Adicionado o template `topics.html` com loop `{% for topic in topics %}`
- Registrada nova rota em `urls.py` para `/topics`
- Template exibe os tópicos disponíveis ou uma mensagem padrão se nenhum tópico for encontrado

Closes #9 