### PR TITLE
#11 feat: exibir detalhes do topico e suas entradas relacionadas

### DIFF
--- a/learning_logs/templates/learning_logs/topic.html
+++ b/learning_logs/templates/learning_logs/topic.html
@@ -1,0 +1,27 @@
+{% extends "learning_logs/base.html" %}
+
+{% block content %}
+
+    <h3>Tópico: {{ topic }}</h3>
+
+    <p>Entradas: </p>
+    <ul>
+        {% for entry in entries %}
+
+        <li>
+            <p>{{ entry.date_added | date:'M d, Y H:i' }}</p>
+            <p>{{ entry.text | linebreaks }}</p>
+        </li>
+
+        {% empty%}
+
+        <li>
+            Não ha registros.
+
+        </li>
+
+        {% endfor %}
+
+    </ul>
+
+{% endblock content %}

--- a/learning_logs/templates/learning_logs/topics.html
+++ b/learning_logs/templates/learning_logs/topics.html
@@ -1,6 +1,7 @@
 {% extends "learning_logs/base.html" %}
 
 {% block content %} 
+    Tópicos:
 
     <ul>
         {% for topic in topics%}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('topics', views.topics, name='topics'),
+    path('topic/<topic_id>/', views.topic, name='topic'),
 ]

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -10,3 +10,10 @@ def topics(request):
     topics = Topic.objects.order_by('date_added')
     context = {'topics': topics}
     return render(request, 'learning_logs/topics.html', context)
+
+def topic(request, topic_id):
+    """Mostra um único assunto e todas as suas entradas"""
+    topic = Topic.objects.get(id = topic_id)
+    entries = topic.entry_set.order_by('-date_added')
+    context = {'topic': topic, 'entries': entries}
+    return render(request, 'learning_logs/topic.html', context)


### PR DESCRIPTION
- Criada a view `topic(request, topic_id)` no `views.py`
- Implementada a lógica para buscar o tópico pelo ID e listar suas entradas ordenadas por `date_added`
- Criado o template `topic.html` com loop para exibir cada entrada associada
- Adicionada rota dinâmica `topic/<topic_id>/` no `urls.py`
- Ajustado o template `topics.html` para exibir o nome da seção “Tópicos:”

Closes #11 