### PR TITLE
#13 feat: adicionar links para paginas de detalhe dos topicos

### DIFF
--- a/learning_logs/templates/learning_logs/base.html
+++ b/learning_logs/templates/learning_logs/base.html
@@ -1,3 +1,4 @@
-<a href="{% url 'index' %}"> <h1>Learning_Log</h1>  </a>
+<a href="{% url 'index' %}">Learning_Log</a> -
+<a href="{% url 'topics' %}">Tópicos</a>
 
 {% block content%}{% endblock content %}

--- a/learning_logs/templates/learning_logs/topics.html
+++ b/learning_logs/templates/learning_logs/topics.html
@@ -5,7 +5,9 @@
 
     <ul>
         {% for topic in topics%}
-            <li> {{ topic }} </li>
+            <li>
+                <a href="{% url 'topic' topic.id %}"> {{ topic }} </a>
+            </li>
         {% empty %}
             <li>Nenhum tópico foi adicionado ainda.</li>
         {% endfor %}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -4,5 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('topics', views.topics, name='topics'),
-    path('topic/<topic_id>/', views.topic, name='topic'),
+    path('topics/<topic_id>/', views.topic, name='topic'),
 ]


### PR DESCRIPTION
- Atualizado o template `topics.html` para transformar cada `<li>` em um link clicável usando `{% url 'topic' topic.id %}`
- Corrigida a rota no `urls.py` para `/topics/<topic_id>/` (antes estava apenas como `topic/<topic_id>/`)
- Ajustado o `base.html` para incluir navegação entre as páginas `Home` e `Tópicos`

Closes #13 