### PR TITLE
#15 feat: Adiciona funcionalidade de criação de novos tópicos

### DIFF
--- a/learning_logs/forms.py
+++ b/learning_logs/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import Topic
+
+class TopicForm(forms.ModelForm):
+    class Meta: 
+        model = Topic
+        fields = ['text']
+        labels = {'text': ''}

--- a/learning_logs/templates/learning_logs/new_topic.html
+++ b/learning_logs/templates/learning_logs/new_topic.html
@@ -1,0 +1,11 @@
+{% extends "learning_logs/base.html" %}
+
+{% block content %}
+
+    <form action="{% url 'new_topic' %}" method='post'>
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button name="submit">Adicionar</button>
+    </form>
+
+{% endblock content %}

--- a/learning_logs/templates/learning_logs/topics.html
+++ b/learning_logs/templates/learning_logs/topics.html
@@ -13,4 +13,6 @@
         {% endfor %}
     </ul>
 
+    <a href="{% url 'new_topic' %}">Adicionar novos tópicos</a>
+
 {% endblock content %}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('topics', views.topics, name='topics'),
     path('topics/<topic_id>/', views.topic, name='topic'),
+    path('new_topic', views.new_topic, name='new_topic'),
 ]

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -1,5 +1,8 @@
 from django.shortcuts import render
 from .models import Topic
+from .forms import TopicForm
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 def index(request):
     """Pagina principal do Learning_Log"""
@@ -17,3 +20,17 @@ def topic(request, topic_id):
     entries = topic.entry_set.order_by('-date_added')
     context = {'topic': topic, 'entries': entries}
     return render(request, 'learning_logs/topic.html', context)
+
+def new_topic(request):
+    """Adiciona um novo assunto."""
+    if request.method != 'POST': 
+        # Nenhum dado submetido, cria um formulario em branco
+        form = TopicForm()
+    else:
+        # Dados de POST submetidos, processa os dados.
+        form = TopicForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return HttpResponseRedirect(reverse('topics'))
+    context = {'form' : form}
+    return render(request, 'learning_logs/new_topic.html', context)


### PR DESCRIPTION
## Mudanças realizadas:

* **urls.py:** Adicionada uma nova rota `new_topic/` que aponta para a view `views.new_topic`.
* **views.py:** Criada a view `new_topic` que gerencia a renderização e o processamento do formulário de novo tópico. Em caso de sucesso no envio (POST), o usuário é redirecionado para a página de tópicos.
* **forms.py:** Criado o arquivo `forms.py` com o `TopicForm`, um ModelForm para o modelo `Topic`, simplificando a criação e validação do formulário.
* **templates/new_topic.html:** Criado um novo template para a página de adição, que exibe o formulário para o usuário.
* **templates/topics.html:** Adicionado um link na página principal de tópicos para "Adicionar novos tópicos", direcionando o usuário para a nova funcionalidade.

Closes #15 