### PR TITLE
#19 feat: Permite a edição de anotações existentes

### DIFF
--- a/learning_logs/templates/learning_logs/edit_entry.html
+++ b/learning_logs/templates/learning_logs/edit_entry.html
@@ -1,0 +1,15 @@
+{% extends "learning_logs/base.html" %}
+
+{% block content %}
+
+<p><a href="[% url 'topic' topic.id %]"> {{ topic }} </a></p>
+
+<p>Editar anotação:</p>
+
+<form action="{% url 'edit_entry' entry.id %}" method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button name="submit">Salvar</button>
+</form>
+
+{% endblock content %}

--- a/learning_logs/templates/learning_logs/topic.html
+++ b/learning_logs/templates/learning_logs/topic.html
@@ -16,6 +16,9 @@
         <li>
             <p>{{ entry.date_added | date:'M d, Y H:i' }}</p>
             <p>{{ entry.text | linebreaks }}</p>
+            <p>
+                <a href="{% url 'edit_entry' entry.id %}">Editar anotação</a>
+            </p>
         </li>
 
         {% empty%}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('topics/<topic_id>/', views.topic, name='topic'),
     path('new_topic', views.new_topic, name='new_topic'),
     path('new_entry/<topic_id>', views.new_entry, name='new_entry'),
+    path('edit_entry/<entry_id>', views.edit_entry, name='edit_entry'),
 ]

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from .models import Topic
+from .models import Topic, Entry
 from .forms import TopicForm, EntryForm
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -50,3 +50,19 @@ def new_entry(request, topic_id):
             return HttpResponseRedirect(reverse('topic', args=[topic_id]))
     context = {'topic':topic, 'form':form}
     return render(request, 'learning_logs/new_entry.html', context)
+
+def edit_entry(request, entry_id):
+    """Edita uma entrada ja existente"""
+    entry = Entry.objects.get(id=entry_id)
+    topic = entry.topic
+
+    if request.method != 'POST':
+        form = EntryForm(instance=entry)
+    else:
+        form = EntryForm(instance=entry, data=request.POST)
+        if form.is_valid():
+            form.save()
+            return HttpResponseRedirect(reverse('topic', args=[topic.id]))
+
+    context = {'entry': entry, 'topic': topic, 'form':form}
+    return render(request, 'learning_logs/edit_entry.html', context)


### PR DESCRIPTION
## Mudanças realizadas:

* **urls.py:** Adicionada a nova rota `edit_entry/<int:entry_id>/` para a página de edição.
* **views.py:** Criada a view `edit_entry`, que carrega a anotação existente em um formulário, processa as alterações via POST e salva o conteúdo atualizado.
* **templates/edit_entry.html:** Criado um novo template que renderiza o formulário de edição.
* **templates/topic.html:** Na lista de anotações de um tópico, um link para "Editar anotação" foi adicionado a cada item, apontando para a sua respectiva página de edição.

Closes #19 