### PR TITLE
#21 feat: Adiciona funcionalidade para excluir anotações

### DIFF
--- a/learning_logs/templates/learning_logs/base.html
+++ b/learning_logs/templates/learning_logs/base.html
@@ -1,4 +1,6 @@
-<a href="{% url 'index' %}">Learning_Log</a> -
-<a href="{% url 'topics' %}">Tópicos</a>
+<p>
+    <a href="{% url 'index' %}">Learning_Log</a> -
+    <a href="{% url 'topics' %}">Tópicos</a>
+</p>
 
 {% block content%}{% endblock content %}

--- a/learning_logs/templates/learning_logs/delete_entry.html
+++ b/learning_logs/templates/learning_logs/delete_entry.html
@@ -1,0 +1,19 @@
+{% extends 'learning_logs/base.html' %}
+
+{% block content %}
+
+<p>Tem certeza que deseja excluir a entrada?</p>
+
+<div class="card my-3">
+    <div class="card-body">
+        {{ entry.text|linebreaks }}
+    </div>
+</div>
+
+<form method="post">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-danger">Sim, excluir</button>
+    <a href="{% url 'topic' topic.id %}" class="btn btn-secondary">Cancelar</a>
+</form>
+
+{% endblock content %}

--- a/learning_logs/templates/learning_logs/topic.html
+++ b/learning_logs/templates/learning_logs/topic.html
@@ -19,6 +19,11 @@
             <p>
                 <a href="{% url 'edit_entry' entry.id %}">Editar anotação</a>
             </p>
+
+            <p>
+                <a href="{% url 'delete_entry' entry.id %}">Apagar anotação</a>
+            </p>
+
         </li>
 
         {% empty%}

--- a/learning_logs/urls.py
+++ b/learning_logs/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('new_topic', views.new_topic, name='new_topic'),
     path('new_entry/<topic_id>', views.new_entry, name='new_entry'),
     path('edit_entry/<entry_id>', views.edit_entry, name='edit_entry'),
-]
+    path('delete_entry/<entry_id>', views.delete_entry, name='delete_entry')
+]  

--- a/learning_logs/views.py
+++ b/learning_logs/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from .models import Topic, Entry
 from .forms import TopicForm, EntryForm
 from django.http import HttpResponseRedirect
@@ -31,7 +31,7 @@ def new_topic(request):
         form = TopicForm(request.POST)
         if form.is_valid():
             form.save()
-            return HttpResponseRedirect(reverse('topics'))
+            return redirect('learning_logs:topics')
     context = {'form' : form}
     return render(request, 'learning_logs/new_topic.html', context)
 
@@ -47,7 +47,7 @@ def new_entry(request, topic_id):
             new_entry = form.save(commit=False)
             new_entry.topic = topic
             new_entry.save()
-            return HttpResponseRedirect(reverse('topic', args=[topic_id]))
+            return redirect('learning_logs:topic', topic_id=topic.id) 
     context = {'topic':topic, 'form':form}
     return render(request, 'learning_logs/new_entry.html', context)
 
@@ -62,7 +62,20 @@ def edit_entry(request, entry_id):
         form = EntryForm(instance=entry, data=request.POST)
         if form.is_valid():
             form.save()
-            return HttpResponseRedirect(reverse('topic', args=[topic.id]))
+            return redirect('learning_logs:topic', topic_id=topic.id)
 
     context = {'entry': entry, 'topic': topic, 'form':form}
     return render(request, 'learning_logs/edit_entry.html', context)
+
+def delete_entry(request, entry_id):
+    """Exclui uma entrada ja existente"""
+    entry = Entry.objects.get(id=entry_id)
+    topic = entry.topic
+
+    if request.method == 'POST':
+        #Se o usuario confirmou no formulario, deleta o objeto
+        entry.delete()
+        return redirect('topic', topic_id=topic.id)
+
+    context = {'entry': entry, 'topic': topic}
+    return render(request, 'learning_logs/delete_entry.html', context)


### PR DESCRIPTION
## Mudanças realizadas:

* **urls.py:** Adicionada a rota `delete_entry/<int:entry_id>/`.
* **views.py:** Implementada a view `delete_entry`, que lida com a exibição de uma página de confirmação (GET) e com a exclusão da anotação (POST).
* **templates/delete_entry.html:** Criado um novo template para a página de confirmação, que visa prevenir a exclusão acidental por parte do usuário.
* **templates/topic.html:** Adicionado um link "Apagar anotação" em cada entrada na página de detalhes do tópico.

Closes #21 